### PR TITLE
ARXIVNG-2073 added feature to support relative static paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,125 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+requirements.txt
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# sphinx
+docs/source/_build
+
+# mypy
+.mypy_cache/
+
+.coverage
+.DS_Store
+zero.db
+
+# Editor files & misc
+*~
+*.idea
+*.vscode
+default.nix
+*.db
+*#*
+*.#*
+
+*.pyc
+build/
+dist/
+*.egg-info/
+*.DS_Store
+.sass-cache/

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,33 @@
-
-export REPO_ORG=arxiv
-export REPO_NAME=arxiv-docs
-export REPO_PATH=/dev/null
-export TARGET_REPO=git@github.com:${REPO_ORG}/${REPO_NAME}.git
-export SOURCE_REF=0.0.0
-export SOURCE_DIR=help
-export SITE_NAME=help
-export SITE_HUMAN_NAME="arXiv Help Pages"
-export IMAGE_NAME=arxiv/help
-export TMP_DIR=/tmp/docs-build
-export PROJECT_NAME=arXiv Static
-export BUILD_TIME=`date`
-export NOCACHE=`date +%s`
-
-
-remote: Makefile
-	./bin/make_remote.sh && \
-		rm -rf ./source && mkdir ./source &&  \
-		cp -R ${TMP_DIR}/* ./source && \
-		cp -R ${REPO_PATH}/.git ./source && \
-		docker build ./ \
-			--build-arg NOCACHE=${NOCACHE} \
-			--build-arg VERSION=${SOURCE_REF} \
-			--build-arg BUILD_TIME=$(date) \
-			--build-arg SOURCE=${REPO_ORG}/${REPO_NAME} \
-			--build-arg SOURCE_DIR=${SOURCE_DIR} \
-			--build-arg SITE_NAME=${SITE_NAME} \
-			--build-arg SITE_HUMAN_NAME="${SITE_HUMAN_NAME}" \
-		 	-f ./Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF} && \
-		rm -rf ./source
+REPO_ORG?=arxiv
+REPO_NAME?=arxiv-docs
+REPO_PATH?=.
+TARGET_REPO?=git@github.com:${REPO_ORG}/${REPO_NAME}.git
+SOURCE_REF?=0.0.0
+SOURCE_DIR?=help
+SITE_NAME?=help
+SITE_HUMAN_NAME?="arXiv Help Pages"
+SITE_HUMAN_SHORT_NAME?=Help
+SITE_SEARCH_ENABLED?=1
+IMAGE_NAME?=arxiv/help
+BUILD_TIME?=$(date)
+NOCACHE?=`date +%s`
 
 local: Makefile
-	echo "Build locally at "${BUILD_TIME} && \
-	rm -rf ./source && mkdir ./source &&  \
-	cp -R ${REPO_PATH}/* ./source && \
-	cp -R ${REPO_PATH}/.git ./source && \
-	ls -la ./source && \
-	echo """docker build ./ \
-		--build-arg NOCACHE=${NOCACHE} \
-		--build-arg VERSION=${SOURCE_REF} \
-		--build-arg BUILD_TIME="${BUILD_TIME}" \
-		--build-arg SOURCE=${REPO_ORG}/${REPO_NAME} \
-		--build-arg SITE_NAME=${SITE_NAME} \
-		--build-arg SITE_HUMAN_NAME=${SITE_HUMAN_NAME} \
-		-f ./Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF}""" && \
-	docker build ./ \
+	echo "Build locally at "${BUILD_TIME}
+	rm -rf ./build
+	mkdir ./build
+	mkdir ./build/${SOURCE_DIR}
+	cp -R ${REPO_PATH}/${SOURCE_DIR}/* ./build/${SOURCE_DIR}/
+	cp -R ${REPO_PATH}/.git ./build
+	docker build . \
 		--build-arg NOCACHE=${NOCACHE} \
 		--build-arg VERSION=${SOURCE_REF} \
 		--build-arg BUILD_TIME="${BUILD_TIME}" \
 		--build-arg SOURCE=${REPO_ORG}/${REPO_NAME} \
 		--build-arg SOURCE_DIR=${SOURCE_DIR} \
+		--build-arg SITE_SEARCH_ENABLED=${SITE_SEARCH_ENABLED} \
 		--build-arg SITE_NAME=${SITE_NAME} \
-		--build-arg SITE_HUMAN_NAME="${SITE_HUMAN_NAME}" \
-		-f ./Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF} && \
-	rm -rf ./source
+		--build-arg SITE_HUMAN_NAME='${SITE_HUMAN_NAME}' \
+		--build-arg SITE_HUMAN_SHORT_NAME=${SITE_HUMAN_SHORT_NAME} \
+		-f ./Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF}
+	rm -rf ./build

--- a/arxiv/marxdown/config.py
+++ b/arxiv/marxdown/config.py
@@ -61,3 +61,6 @@ JIRA_COLLECTOR_URL = os.environ.get(
 )
 RELEASE_NOTES_URL = "https://"
 RELEASE_NOTES_TEXT = "v0.2 released 2019-02-11"
+
+RELATIVE_STATIC_PATHS = bool(int(os.environ.get('RELATIVE_STATIC_PATHS', '0')))
+"""If true, all static paths are under ``SITE_URL_PREFIX``."""

--- a/arxiv/marxdown/factory.py
+++ b/arxiv/marxdown/factory.py
@@ -52,9 +52,10 @@ def create_web_app(build_path: Optional[str] = None,
 
     Base(app)
 
-    app.register_blueprint(routes.docs)     # Provides base templates.
-
     with app.app_context():     # Need the app context for the config to stick.
+        # Provides base templates.
+        app.register_blueprint(routes.get_docs_blueprint(app))
+
         # We build the blueprint on the fly, so that we get dynamic routing
         # to content pages.
         app.register_blueprint(
@@ -63,6 +64,7 @@ def create_web_app(build_path: Optional[str] = None,
                 with_search=with_search
             )
         )
+
     app.jinja_env.filters['format_datetime'] = format_datetime
     app.jinja_env.filters['simepledate'] = simepledate
     app.jinja_env.filters['pretty_path'] = pretty_path

--- a/arxiv/marxdown/routes.py
+++ b/arxiv/marxdown/routes.py
@@ -6,7 +6,7 @@ from werkzeug.urls import url_parse, url_unparse, url_encode
 from werkzeug.exceptions import NotFound
 import jinja2
 from flask_s3 import url_for as s3_url_for
-from flask import Blueprint, render_template_string, request, \
+from flask import Flask, Blueprint, render_template_string, request, \
     render_template, current_app, url_for, redirect, Response
 
 from arxiv import status
@@ -146,7 +146,14 @@ def get_blueprint(site_path: str, with_search: bool = True) -> Blueprint:
     return blueprint
 
 
-docs = Blueprint('docs', __name__, url_prefix='/_marxdown',
-                 static_folder='static',
-                 template_folder='templates',
-                 static_url_path='static')
+def get_docs_blueprint(app: Flask) -> Blueprint:
+    """Generate a blueprint for base marXdown static files and templates."""
+    if app.config.get('RELATIVE_STATIC_PATHS'):
+        url_prefix = f'{site.get_url_prefix()}/_marxdown'
+    else:
+        url_prefix = '/_marxdown'
+    return Blueprint('docs', __name__,
+                     url_prefix=url_prefix,
+                     static_folder='static',
+                     template_folder='templates',
+                     static_url_path='static')

--- a/arxiv/marxdown/tests/test_static.py
+++ b/arxiv/marxdown/tests/test_static.py
@@ -23,6 +23,50 @@ CONFIG = mock.MagicMock(**{
 })
 
 
+class TestRelativeStaticPaths(TestCase):
+    """Test relative static paths feature."""
+
+    @mock.patch(f'{factory.__name__}.config',
+                mock.MagicMock(**{
+                    'BUILD_PATH': BUILD_DIR,
+                    'SITE_NAME': SITE_NAME,
+                    'SITE_HUMAN_NAME': 'The test site of testiness',
+                    'SITE_HUMAN_SHORT_NAME': 'Test site',
+                    'SITE_SEARCH_ENABLED': 1,
+                    'FLASKS3_BUCKET_NAME': BUCKET,
+                    'FLASKS3_ACTIVE': 1,
+                    'APP_VERSION': APP_VERSION,
+                    'RELATIVE_STATIC_PATHS': True,
+                    'SITE_URL_PREFIX': '/test'
+                }))
+    def test_use_relative(self):
+        """Relative static paths feature is enabled."""
+        app = factory.create_web_app()
+        self.assertTrue(app.blueprints['docs'].url_prefix.startswith('/test'),
+                        'The blueprint is mounted below the site URL prefix.')
+
+    @mock.patch(f'{factory.__name__}.config',
+                mock.MagicMock(**{
+                    'BUILD_PATH': BUILD_DIR,
+                    'SITE_NAME': SITE_NAME,
+                    'SITE_HUMAN_NAME': 'The test site of testiness',
+                    'SITE_HUMAN_SHORT_NAME': 'Test site',
+                    'SITE_SEARCH_ENABLED': 1,
+                    'FLASKS3_BUCKET_NAME': BUCKET,
+                    'FLASKS3_ACTIVE': 1,
+                    'APP_VERSION': APP_VERSION,
+                    'RELATIVE_STATIC_PATHS': False,
+                    'SITE_URL_PREFIX': '/test'
+                }))
+    def test_dont_use_relative(self):
+        """Relative static paths feature is enabled."""
+        app = factory.create_web_app()
+        self.assertTrue(
+            app.blueprints['docs'].url_prefix.startswith('/_marxdown'),
+            'The blueprint is mounted at the root path.'
+        )
+
+
 class TestUploadStaticFiles(TestCase):
     """Test uploading of static files to S3."""
 

--- a/arxiv/marxdown/wsgi.py
+++ b/arxiv/marxdown/wsgi.py
@@ -4,9 +4,14 @@ import os
 from .factory import create_web_app
 
 
+__flask_app__ = create_web_app()
+
+
 def application(environ, start_response):
     """WSGI application factory."""
     for key, value in environ.items():
+        if key == 'SERVER_NAME':
+            continue
         os.environ[key] = str(value)
-    app = create_web_app()
-    return app(environ, start_response)
+        __flask_app__.config[key] = str(value)
+    return __flask_app__(environ, start_response)


### PR DESCRIPTION
If ``RELATIVE_STATIC_PATHS`` is True, static assets attached to marxdown blueprints will be served under ``SITE_URL_PREFIX``. E.g. ``/_marxdown/...`` --> ``/help/_marxdown/...``.

Together with https://github.com/arXiv/arxiv-base/pull/116, this should fix the problem that static URLs don't work when a site is deployed as a container on a sub path.